### PR TITLE
Encoding config files with UTF16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,6 @@ require (
 	github.com/rs/cors v1.7.0
 	github.com/sirupsen/logrus v1.8.1
 	golang.org/x/sys v0.0.0-20210603125802-9665404d3644 // indirect
+	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,9 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644 h1:CA1DEQ4NdKphKeL70tvsWNdT5oFh1lOjihRcEDROi0I=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=

--- a/server/list.go
+++ b/server/list.go
@@ -93,10 +93,6 @@ func loadConfigFromFile(config interface{}, path string) error {
 
 	r := transform.NewReader(f, utf16Encoding.NewDecoder().Transformer)
 
-	if err != nil {
-		return err
-	}
-
 	if err := json.NewDecoder(r).Decode(config); err != nil {
 		return err
 	}

--- a/server/save.go
+++ b/server/save.go
@@ -2,13 +2,14 @@ package server
 
 import (
 	"encoding/json"
-	"github.com/assetto-corsa-web/accweb/cfg"
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
 	"time"
+
+	"github.com/assetto-corsa-web/accweb/cfg"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -103,14 +104,21 @@ func saveConfigToFile(config interface{}, dir, name string) error {
 	data, err := json.Marshal(config)
 
 	if err != nil {
-		logrus.WithField("err", err).Error("Error marshalling server configuration")
+		logrus.WithError(err).Error("Error marshalling server configuration")
+		return err
+	}
+
+	encodedData, err := utf16Encoding.NewEncoder().Bytes(data)
+
+	if err != nil {
+		logrus.WithError(err).Error("Error encoding to UTF16")
 		return err
 	}
 
 	path := filepath.Join(dir, name)
 	logrus.WithField("path", path).Debug("Saving server configuration file")
 
-	if err := ioutil.WriteFile(path, data, 0655); err != nil {
+	if err := ioutil.WriteFile(path, encodedData, 0655); err != nil {
 		logrus.WithField("err", err).Error("Error saving server configuration file")
 		return err
 	}


### PR DESCRIPTION
Encoding config files according to the manual.

> III.2 Configuration files
The server is exclusively configured via JSON files in UTF16-LE format. Using UTF8 file 
encodings may seem to work but will lead to wrong readings

fix #91 