### PR TITLE
Added Priority and Core Affinity settings for Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,6 @@ require (
 	github.com/rs/cors v1.7.0
 	github.com/sirupsen/logrus v1.8.1
 	golang.org/x/sys v0.0.0-20210603125802-9665404d3644 // indirect
-	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/text v0.3.7
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/public/src/components/server_config/basic.vue
+++ b/public/src/components/server_config/basic.vue
@@ -23,7 +23,7 @@ export default {
             priorities: [
                 {value: 256, label: "Realtime"},
                 {value: 128, label: "High"},
-                {value: 32768, label: "Above Normal	"},
+                {value: 32768, label: "Above Normal"},
                 {value: 32, label: "Normal"},
                 {value: 16384, label: "Below Normal"},
                 {value: 64, label: "Low"},

--- a/public/src/components/server_config/basic.vue
+++ b/public/src/components/server_config/basic.vue
@@ -1,6 +1,6 @@
 <template>
     <collapsible :title="$t('title')">
-		<selection :label="$t('priority_label')" :options="priorities" v-model="priority"></selection>
+        <selection :label="$t('priority_label')" :options="priorities" v-model="priority"></selection>
         <field type="text" :label="$t('affinty_label')" v-model="coreAffinity"></field>
         <field type="number" :label="$t('udp_label')" v-model="udpPort"></field>
         <field type="number" :label="$t('tcp_label')" v-model="tcpPort"></field>
@@ -20,7 +20,7 @@ export default {
     components: {collapsible, field, selection, checkbox},
     data() {
         return {
-			priorities: [
+            priorities: [
                 {value: 256, label: "Realtime"},
                 {value: 128, label: "High"},
                 {value: 32768, label: "Above Normal	"},
@@ -39,7 +39,7 @@ export default {
     },
     methods: {
         setData(data) {
-			this.priority = data.priority;
+            this.priority = data.priority;
             this.coreAffinity = data.coreAffinity;
             this.udpPort = data.udpPort;
             this.tcpPort = data.tcpPort;
@@ -49,7 +49,7 @@ export default {
         },
         getData() {
             return {
-				priority: parseInt(this.priority),
+                priority: parseInt(this.priority),
                 coreAffinity: this.coreAffinity,
                 udpPort: parseInt(this.udpPort),
                 tcpPort: parseInt(this.tcpPort),
@@ -66,7 +66,7 @@ export default {
 {
     "en": {
         "title": "Basic configuration",
-		"priority_label": "Process priority",
+        "priority_label": "Process priority",
         "affinty_label": "Core affinity (leave blank if you don't know what to do)",
         "udp_label": "UDP port",
         "tcp_label": "TCP port",

--- a/public/src/components/server_config/basic.vue
+++ b/public/src/components/server_config/basic.vue
@@ -1,5 +1,7 @@
 <template>
     <collapsible :title="$t('title')">
+		<selection :label="$t('priority_label')" :options="priorities" v-model="priority"></selection>
+        <field type="text" :label="$t('affinty_label')" v-model="coreAffinity"></field>
         <field type="number" :label="$t('udp_label')" v-model="udpPort"></field>
         <field type="number" :label="$t('tcp_label')" v-model="tcpPort"></field>
         <field type="number" :label="$t('maxconnections_label')" v-model="maxConnections"></field>
@@ -11,12 +13,23 @@
 <script>
 import collapsible from "../collapsible.vue";
 import field from "../field.vue";
+import selection from "../selection.vue";
 import checkbox from "../checkbox.vue";
 
 export default {
-    components: {collapsible, field, checkbox},
+    components: {collapsible, field, selection, checkbox},
     data() {
         return {
+			priorities: [
+                {value: 256, label: "Realtime"},
+                {value: 128, label: "High"},
+                {value: 32768, label: "Above Normal	"},
+                {value: 32, label: "Normal"},
+                {value: 16384, label: "Below Normal"},
+                {value: 64, label: "Low"},
+            ],
+            priority: 32,
+            coreAffinity: "",
             udpPort: 9600,
             tcpPort: 9600,
             maxConnections: 10,
@@ -26,6 +39,8 @@ export default {
     },
     methods: {
         setData(data) {
+			this.priority = data.priority;
+            this.coreAffinity = data.coreAffinity;
             this.udpPort = data.udpPort;
             this.tcpPort = data.tcpPort;
             this.maxConnections = data.maxConnections;
@@ -34,6 +49,8 @@ export default {
         },
         getData() {
             return {
+				priority: parseInt(this.priority),
+                coreAffinity: this.coreAffinity,
                 udpPort: parseInt(this.udpPort),
                 tcpPort: parseInt(this.tcpPort),
                 maxConnections: parseInt(this.maxConnections),
@@ -49,6 +66,8 @@ export default {
 {
     "en": {
         "title": "Basic configuration",
+		"priority_label": "Process priority",
+        "affinty_label": "Core affinity (leave blank if you don't know what to do)",
         "udp_label": "UDP port",
         "tcp_label": "TCP port",
         "maxconnections_label": "Max. connections",

--- a/server/instance.go
+++ b/server/instance.go
@@ -330,8 +330,7 @@ func StopServer(id int) error {
 		if fwTcpErr != nil {
 			logrus.WithError(fwTcpErr).Error("Error closing TCP Port")
 		} else {
-			logrus.Info("Closed TCP Port " + strconv.Itoa(server.Configuration.TcpPort))
-			logrus.WithField("Command", fwTcpCmd.String()).Info("Closed TCP Port")
+			logrus.WithField("Command", fwTcpCmd.String()).WithField("Port", server.Configuration.TcpPort).Info("Closed TCP Port")
 		}
 		
 		fwUdpArgs := []string{"advfirewall", "firewall", "del", "rule", "name=\"ACCSERVER_" + strconv.Itoa(server.Id) + "\""}

--- a/server/server.go
+++ b/server/server.go
@@ -20,6 +20,8 @@ type ServerSettings struct {
 }
 
 type ConfigurationJson struct {
+	Priority        int `json:"priority"`
+	Affinity        string `json:"coreAffinity"`
 	ConfigVersion   int `json:"configVersion"`
 	UdpPort         int `json:"udpPort"`
 	TcpPort         int `json:"tcpPort"`


### PR DESCRIPTION
Added Process priortiy and Core affinity settings (Windows only). Both settings can be found under "Basic configuration" for each Server.

- Process priority is set via dropdown that represents the priority setting from Task Manager. 
   **Default is "Normal"**

- Core affinity is a textfield which expects a comma seperated list of CPU Cores from 1 to <CoreCount>. Values below 0 and above CoreCount will be ignored and reported as Warning in Server Log. If field is left blank, all cores are selected (this is the default behaviour like before). CoreCount will be determined automatically
   **Default is Empty**