### PR TITLE
feat: Attach labels to their input elements

### DIFF
--- a/public/src/components/checkbox.vue
+++ b/public/src/components/checkbox.vue
@@ -1,10 +1,12 @@
 <template>
     <div class="checkbox">
-        <input v-bind:value="value"
-               v-on:input="$emit('input', $event.target.checked)"
-               v-bind:checked="value"
-               type="checkbox" />
-        <label>{{label}}</label>
+        <label>
+          <input v-bind:value="value"
+                 v-on:input="$emit('input', $event.target.checked)"
+                 v-bind:checked="value"
+                 type="checkbox" />
+          {{label}}
+        </label>
         <div class="error" v-show="error">{{error}}</div>
     </div>
 </template>

--- a/public/src/components/field.vue
+++ b/public/src/components/field.vue
@@ -1,11 +1,13 @@
 <template>
     <div>
-        <label>{{label}}</label>
-        <input :type="type"
-            :placeholder="placeholder"
-            v-bind:value="value"
-            v-on:input="$emit('input', $event.target.value)"
-            :step="step" />
+        <label>
+          {{label}}
+          <input :type="type"
+              :placeholder="placeholder"
+              v-bind:value="value"
+              v-on:input="$emit('input', $event.target.value)"
+              :step="step" />
+        </label>
         <div class="error" v-show="error">{{error}}</div>
     </div>
 </template>

--- a/public/src/components/selection.vue
+++ b/public/src/components/selection.vue
@@ -1,12 +1,13 @@
 <template>
     <div>
-        <label>{{label}}</label>
-        <div>
+        <label>
+            {{label}}
+
             <select v-bind:value="value"
                 v-on:input="$emit('input', $event.target.value)">
                 <option v-for="o in options" v-bind:value="o.value">{{o.label}}</option>
             </select>
-        </div>
+        </label>
         <div class="error" v-show="error">{{error}}</div>
     </div>
 </template>

--- a/public/src/main.scss
+++ b/public/src/main.scss
@@ -246,6 +246,7 @@ input[type~="checkbox"] {
 
 select {
 	width: auto;
+	display: block;
 }
 
 label {


### PR DESCRIPTION
This makes the labels more useful - they now label their actual input elements, and become clickable. This is in particular useful for the checkboxes, as you can now get away with simply clicking the text without having to hit the box.

The small CSS change makes sure the select pulldowns are still kept on their own line (since they're inline by default). The old component had a "hack" where the select element was wrapped in a div to achieve this.

Another option would be to generate a unique id inside each component and attach that id to the input element, and then use the `for` attribute on the label to attach it to the element. That would require getting a decent, unique id for each component, which would probably make another dependency necessary. Since a label can keep the element it is labeling inside itself instead and avoid adding extra complexity, this solution was chosen.