### PR TITLE
feat: Build and release new versions through Github actions

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -1,0 +1,30 @@
+name: Build and release accweb
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  build-accweb:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout and setup
+        uses: actions/checkout@v2
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.17.7'
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - name: Build accweb release
+        run: chmod u+x ./build/build_release.sh && ./build/build_release.sh ${{ steps.get_version.outputs.VERSION }}
+      - name: Extract release information from CHANGELOG.md
+        # Extract every line from ## (set flag), if flag has become 2, exit - `flag` at tne end indicates if row should be included if > 0
+        run: awk '/##/{flag+=1}flag==2{exit};flag' CHANGELOG.md > RELEASE.md
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: 'releases/accweb_${{ steps.get_version.outputs.VERSION }}.zip'
+          bodyFile: 'RELEASE.md'
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This patch adds support for building and releasing accweb from tags - every time a new tag is pushed to Github, a release is built through the build release script and uploaded as a released version of accweb on Github. It'll then become visible under "Releases".

The version number is taken from the tag, so any -rc etc. should work as well. The release notes are extracted from the current format of `CHANGELOG.md` by fetching the content between the first and second line that starts with `##`.

The resulting zip file should be the same as before, since its still the same release script being used.

I decided to lock the go version used to the most recent 1.17 release, but this could be changed to always pick the latest one later. 