### PR TITLE
fix: Handling acc server passwords properly  #186

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.16.2
+* Fix server password handler.
+
 ## 1.16.1
 * Fix acc dedicated server create instance. ( #185 )
 * Building releases assets automatically.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -554,11 +554,28 @@ const docTemplate = `{
                 }
             }
         },
+        "app.ExtraAccSettings": {
+            "type": "object",
+            "properties": {
+                "adminPasswordIsEmpty": {
+                    "type": "boolean"
+                },
+                "passwordIsEmpty": {
+                    "type": "boolean"
+                },
+                "spectatorPasswordIsEmpty": {
+                    "type": "boolean"
+                }
+            }
+        },
         "app.InstancePayload": {
             "type": "object",
             "properties": {
                 "acc": {
                     "$ref": "#/definitions/instance.AccConfigFiles"
+                },
+                "accExtraSettings": {
+                    "$ref": "#/definitions/app.ExtraAccSettings"
                 },
                 "accWeb": {
                     "$ref": "#/definitions/instance.AccWebConfigJson"
@@ -661,6 +678,9 @@ const docTemplate = `{
             "properties": {
                 "acc": {
                     "$ref": "#/definitions/instance.AccConfigFiles"
+                },
+                "accExtraSettings": {
+                    "$ref": "#/definitions/app.ExtraAccSettings"
                 },
                 "accWeb": {
                     "$ref": "#/definitions/instance.AccWebConfigJson"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -546,11 +546,28 @@
                 }
             }
         },
+        "app.ExtraAccSettings": {
+            "type": "object",
+            "properties": {
+                "adminPasswordIsEmpty": {
+                    "type": "boolean"
+                },
+                "passwordIsEmpty": {
+                    "type": "boolean"
+                },
+                "spectatorPasswordIsEmpty": {
+                    "type": "boolean"
+                }
+            }
+        },
         "app.InstancePayload": {
             "type": "object",
             "properties": {
                 "acc": {
                     "$ref": "#/definitions/instance.AccConfigFiles"
+                },
+                "accExtraSettings": {
+                    "$ref": "#/definitions/app.ExtraAccSettings"
                 },
                 "accWeb": {
                     "$ref": "#/definitions/instance.AccWebConfigJson"
@@ -653,6 +670,9 @@
             "properties": {
                 "acc": {
                     "$ref": "#/definitions/instance.AccConfigFiles"
+                },
+                "accExtraSettings": {
+                    "$ref": "#/definitions/app.ExtraAccSettings"
                 },
                 "accWeb": {
                     "$ref": "#/definitions/instance.AccWebConfigJson"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -5,10 +5,21 @@ definitions:
       error:
         type: string
     type: object
+  app.ExtraAccSettings:
+    properties:
+      adminPasswordIsEmpty:
+        type: boolean
+      passwordIsEmpty:
+        type: boolean
+      spectatorPasswordIsEmpty:
+        type: boolean
+    type: object
   app.InstancePayload:
     properties:
       acc:
         $ref: '#/definitions/instance.AccConfigFiles'
+      accExtraSettings:
+        $ref: '#/definitions/app.ExtraAccSettings'
       accWeb:
         $ref: '#/definitions/instance.AccWebConfigJson'
       id:
@@ -76,6 +87,8 @@ definitions:
     properties:
       acc:
         $ref: '#/definitions/instance.AccConfigFiles'
+      accExtraSettings:
+        $ref: '#/definitions/app.ExtraAccSettings'
       accWeb:
         $ref: '#/definitions/instance.AccWebConfigJson'
     type: object

--- a/public/src/components/end.vue
+++ b/public/src/components/end.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="end">
-        <a href="https://github.com/assetto-corsa-web/accweb" target="_blank">accweb Version 1.16.1</a>
+        <a href="https://github.com/assetto-corsa-web/accweb" target="_blank">accweb Version 1.16.2</a>
     </div>
 </template>
 

--- a/public/src/components/field.vue
+++ b/public/src/components/field.vue
@@ -6,7 +6,8 @@
               :placeholder="placeholder"
               v-bind:value="value"
               v-on:input="$emit('input', $event.target.value)"
-              :step="step" />
+              :step="step"
+              :disabled="disabled" />
         </label>
         <div class="error" v-show="error">{{error}}</div>
     </div>
@@ -20,6 +21,7 @@ export default {
         label: null,
         placeholder: null,
         step: null,
+        disabled: false,
         error: null
     }
 }

--- a/public/src/components/server_config/settings.vue
+++ b/public/src/components/server_config/settings.vue
@@ -1,5 +1,5 @@
 <template>
-    <collapsible :title="$t('title')" with-import="true" import-filename="settings.json" @load="setData">
+    <collapsible :title="$t('title')" with-import="true" import-filename="settings.json" @load="setDataFile">
         <field :label="$t('servername_label')" v-model="serverName"></field>
         <div class="pwd">
             <field v-if="!passwordIsEmpty" type="password" :label="$t('password_label')" v-model="password" :disabled="passwordIsEmpty"></field>
@@ -97,6 +97,13 @@ export default {
             this.dumpEntryList = data.dumpEntryList;
             this.formationLapType = data.formationLapType;
             this.carGroup = data.carGroup;
+        },
+        setDataFile(data) {
+            data.passwordIsEmpty = data.password === "";
+            data.adminPasswordIsEmpty = data.adminPassword === "";
+            data.spectatorPasswordIsEmpty = data.spectatorPasswordIsEmpty === "";
+            
+            this.setData(data);
         },
         getData() {
             return {

--- a/public/src/components/server_config/settings.vue
+++ b/public/src/components/server_config/settings.vue
@@ -1,9 +1,18 @@
 <template>
     <collapsible :title="$t('title')" with-import="true" import-filename="settings.json" @load="setData">
         <field :label="$t('servername_label')" v-model="serverName"></field>
-        <field type="password" :label="$t('password_label')" v-model="password"></field>
-        <field type="password" :label="$t('adminpassword_label')" v-model="adminPassword"></field>
-        <field type="password" :label="$t('spectatorpassword_label')" v-model="spectatorPassword"></field>
+        <div class="pwd">
+            <field v-if="!passwordIsEmpty" type="password" :label="$t('password_label')" v-model="password" :disabled="passwordIsEmpty"></field>
+            <checkbox :label="$t('password_empty_label')" v-model="passwordIsEmpty"></checkbox>
+        </div>
+        <div class="pwd">
+            <field v-if="!adminPasswordIsEmpty" type="password" :label="$t('adminpassword_label')" v-model="adminPassword" :disabled="adminPasswordIsEmpty"></field>
+            <checkbox :label="$t('adminpassword_empty_label')" v-model="adminPasswordIsEmpty"></checkbox>
+        </div>
+        <div class="pwd">
+            <field v-if="!spectatorPasswordIsEmpty" type="password" :label="$t('spectatorpassword_label')" v-model="spectatorPassword" :disabled="spectatorPasswordIsEmpty"></field>
+            <checkbox :label="$t('spectatorpassword_empty_label')" v-model="spectatorPasswordIsEmpty"></checkbox>
+        </div>
         <field type="number" :label="$t('trackmedalsrequirement_label')" v-model="trackMedalsRequirement"></field>
         <field type="number" :label="$t('safetyratingrequirement_label')" v-model="safetyRatingRequirement"></field>
         <field type="number" :label="$t('racecraftratingrequirement_label')" v-model="racecraftRatingRequirement"></field>
@@ -31,10 +40,13 @@ export default {
     components: {collapsible, field, selection, checkbox},
     data() {
         return {
-            serverName: "Servername",
+            serverName: "Servername (by accweb)",
             password: "",
+            passwordIsEmpty: true,
             adminPassword: "",
+            adminPasswordIsEmpty: true,
             spectatorPassword: "",
+            spectatorPasswordIsEmpty: true,
             trackMedalsRequirement: 0,
             safetyRatingRequirement: -1,
             racecraftRatingRequirement: -1,
@@ -58,7 +70,6 @@ export default {
                 {value: "GT3", label: "Mode GT3"},
                 {value: "GT4", label: "Mode GT4"},
                 {value: "GTC", label: "Mode GTC"},
-
             ],
             carGroup: "FreeForAll"
         };
@@ -67,8 +78,11 @@ export default {
         setData(data) {
             this.serverName = data.serverName;
             this.password = data.password;
+            this.passwordIsEmpty = data.passwordIsEmpty;
             this.adminPassword = data.adminPassword;
+            this.adminPasswordIsEmpty = data.adminPasswordIsEmpty;
             this.spectatorPassword = data.spectatorPassword;
+            this.spectatorPasswordIsEmpty = data.spectatorPasswordIsEmpty;
             this.trackMedalsRequirement = data.trackMedalsRequirement;
             this.safetyRatingRequirement = data.safetyRatingRequirement;
             this.racecraftRatingRequirement = data.racecraftRatingRequirement;
@@ -88,8 +102,11 @@ export default {
             return {
                 serverName: this.serverName,
                 password: this.password,
+                passwordIsEmpty: this.passwordIsEmpty,
                 adminPassword: this.adminPassword,
+                adminPasswordIsEmpty: this.adminPasswordIsEmpty,
                 spectatorPassword: this.spectatorPassword,
+                spectatorPasswordIsEmpty: this.spectatorPasswordIsEmpty,
                 trackMedalsRequirement: parseInt(this.trackMedalsRequirement),
                 safetyRatingRequirement: parseInt(this.safetyRatingRequirement),
                 racecraftRatingRequirement: parseInt(this.racecraftRatingRequirement),
@@ -115,9 +132,12 @@ export default {
     "en": {
         "title": "Server settings",
         "servername_label": "Servername",
-        "password_label": "Password",
-        "adminpassword_label": "Admin password",
-        "spectatorpassword_label": "Spectator Password",
+        "password_label": "Password (leave empty to not update)",
+        "password_empty_label": "Password is Empty",
+        "adminpassword_label": "Admin password (leave empty to not update)",
+        "adminpassword_empty_label": "Admin password is Empty",
+        "spectatorpassword_label": "Spectator Password (leave empty to not update)",
+        "spectatorpassword_empty_label": "Spectator password is Empty",
         "trackmedalsrequirement_label": "Track medals requirement (-1 - 3)",
         "safetyratingrequirement_label": "Safety rating requirement (-1 - 99)",
         "racecraftratingrequirement_label": "Racecraft Training Requirement (-1 - 99)",
@@ -131,7 +151,7 @@ export default {
         "allowautodq_label": "Allow Auto DQ",
         "dumpentrylist_label": "Dump Entry List",
         "formationlaptype_label": "Formation Lap Type",
-		    "cargroup_label": "Car Group"
+		"cargroup_label": "Car Group"
     }
 }
 </i18n>

--- a/public/src/main.scss
+++ b/public/src/main.scss
@@ -233,6 +233,11 @@ input[type~="checkbox"] {
 	margin: 0 8px 0 0;
 }
 
+input[disabled="disabled"] {
+	background-color: $dark_gray;
+	border-color: $gray;
+}
+
 .checkbox {
 	display: flex;
 	justify-content: center;

--- a/public/src/pages/server.vue
+++ b/public/src/pages/server.vue
@@ -55,6 +55,11 @@ export default {
         loadServer() {
             axios.get("/api/instance/"+this.id)
             .then(r => {
+                let settings = r.data.acc.settings;
+                settings.passwordIsEmpty = r.data.accExtraSettings.passwordIsEmpty
+                settings.adminPasswordIsEmpty = r.data.accExtraSettings.adminPasswordIsEmpty
+                settings.spectatorPasswordIsEmpty = r.data.accExtraSettings.spectatorPasswordIsEmpty
+
                 this.servername = r.data.acc.settings.serverName;
                 this.$refs.accweb.setData(r.data.accWeb)
                 this.$refs.basic.setData(r.data.acc.configuration);
@@ -85,6 +90,11 @@ export default {
                     entrylist,
                     bop,
                     assistrules
+                },
+                accExtraSettings: {
+                    passwordIsEmpty: settings.passwordIsEmpty,
+                    adminPasswordIsEmpty: settings.adminPasswordIsEmpty,
+                    spectatorPasswordIsEmpty: settings.spectatorPasswordIsEmpty,
                 }
             };
 


### PR DESCRIPTION
New way of handling acc server passwords.

if you mark as empty, the password field is hidden and the backend will set to empty, if not, you can change the value and if you leave empty, the backend will not update