### PR TITLE
Fix Float values for Rain, Cloud.

### DIFF
--- a/public/src/components/server_config/event.vue
+++ b/public/src/components/server_config/event.vue
@@ -175,9 +175,9 @@ export default {
         },
         toFloat(value) {
             if(typeof value === "string") {
-                return parseFloat(value.replace(",", "."));
+                return parseFloat(value.replace(",", "."), 64);
             }
-
+            
             return value;
         }
     }


### PR DESCRIPTION
Alter parseFloat call to return 64 bit Float.  
Prevents getting values in event.json  like "cloudLevel": 0.20000000298023225 when it should just be 0.2