### PR TITLE
Added "Clear all Entries" function

### DIFF
--- a/public/src/components/server_config/bop.vue
+++ b/public/src/components/server_config/bop.vue
@@ -5,6 +5,7 @@
             :entry="entry"
             v-on:remove="removeEntry"></entry>
         <button v-on:click="addEntry">{{$t("add_entry_button")}}</button>
+        <button v-on:click="clearEntries">{{$t("clear_entries_button")}}</button>
     </collapsible>
 </template>
 
@@ -91,6 +92,11 @@ export default {
             }
 
             return value;
+        },
+        clearEntries(){
+            while(this.entries.length > 0) {
+                this.entries.splice(this.entries[this.entries.length - 1], 1);
+            }
         }
     }
 }
@@ -104,7 +110,8 @@ export default {
         "carModel_label": "Car Model #",
         "ballast_label": "Ballast: 0 to 100kg max.",
 		"restrictor_label": "Motor Restrictor: 0 to 20% max.",
-		"add_entry_button": "Add BOP"
+		"add_entry_button": "Add BOP",
+        "clear_entries_button": "Clear all BOP"
     }
 }
 </i18n>

--- a/public/src/components/server_config/bop.vue
+++ b/public/src/components/server_config/bop.vue
@@ -114,8 +114,8 @@ export default {
         "ballast_label": "Ballast: 0 to 100kg max.",
 		"restrictor_label": "Motor Restrictor: 0 to 20% max.",
 		"add_entry_button": "Add BOP",
-        "clear_entries_button": "Clear all BOP"
-        "confirm_clear_entries": "Do you really want to remove all BOP?",
+        "clear_entries_button": "Clear all BOP",
+        "confirm_clear_entries": "Do you really want to remove all BOP?"    
     }
 }
 </i18n>

--- a/public/src/components/server_config/bop.vue
+++ b/public/src/components/server_config/bop.vue
@@ -94,6 +94,9 @@ export default {
             return value;
         },
         clearEntries(){
+            if (!window.confirm(this.$t("confirm_clear_entries"))) {
+                return;
+            }
             while(this.entries.length > 0) {
                 this.entries.splice(this.entries[this.entries.length - 1], 1);
             }
@@ -112,6 +115,7 @@ export default {
 		"restrictor_label": "Motor Restrictor: 0 to 20% max.",
 		"add_entry_button": "Add BOP",
         "clear_entries_button": "Clear all BOP"
+        "confirm_clear_entries": "Do you really want to remove all BOP?",
     }
 }
 </i18n>

--- a/public/src/components/server_config/bop.vue
+++ b/public/src/components/server_config/bop.vue
@@ -112,8 +112,8 @@ export default {
         "track_label": "Track",
         "carModel_label": "Car Model #",
         "ballast_label": "Ballast: 0 to 100kg max.",
-		"restrictor_label": "Motor Restrictor: 0 to 20% max.",
-		"add_entry_button": "Add BOP",
+        "restrictor_label": "Motor Restrictor: 0 to 20% max.",
+        "add_entry_button": "Add BOP",
         "clear_entries_button": "Clear all BOP",
         "confirm_clear_entries": "Do you really want to remove all BOP?"    
     }

--- a/public/src/components/server_config/entrylist.vue
+++ b/public/src/components/server_config/entrylist.vue
@@ -6,6 +6,7 @@
             v-on:remove="removeEntry"></entry>
         <checkbox :label="$t('forceentrylist_label')" v-model="forceEntryList"></checkbox>
         <button v-on:click="addEntry">{{$t("add_entry_button")}}</button>
+        <button v-on:click="clearEntries">{{$t("clear_entries_button")}}</button>
     </collapsible>
 </template>
 
@@ -44,7 +45,6 @@ export default {
                 });
                 this.entryIndex++;
             }
-
             this.forceEntryList = data.forceEntryList;
         },
         getData() {
@@ -98,7 +98,13 @@ export default {
                     break;
                 }
             }
+        },
+        clearEntries(){
+            while(this.entries.length > 0) {
+                this.entries.splice(this.entries[this.entries.length - 1], 1);
+            }
         }
+        
     }
 }
 </script>
@@ -108,7 +114,8 @@ export default {
     "en": {
         "title": "Entry List",
         "forceentrylist_label": "Force Entry List",
-        "add_entry_button": "Add Entry"
+        "add_entry_button": "Add Entry",
+        "clear_entries_button": "Clear all Entries"
     }
 }
 </i18n>

--- a/public/src/components/server_config/entrylist.vue
+++ b/public/src/components/server_config/entrylist.vue
@@ -118,8 +118,8 @@ export default {
         "title": "Entry List",
         "forceentrylist_label": "Force Entry List",
         "add_entry_button": "Add Entry",
-        "clear_entries_button": "Clear all Entries"
-        "confirm_clear_entries": "Do you really want to remove all entries?",
+        "clear_entries_button": "Clear all Entries",
+        "confirm_clear_entries": "Do you really want to remove all entries?"
     }
 }
 </i18n>

--- a/public/src/components/server_config/entrylist.vue
+++ b/public/src/components/server_config/entrylist.vue
@@ -100,6 +100,9 @@ export default {
             }
         },
         clearEntries(){
+            if (!window.confirm(this.$t("confirm_clear_entries"))) {
+                return;
+            }
             while(this.entries.length > 0) {
                 this.entries.splice(this.entries[this.entries.length - 1], 1);
             }
@@ -116,6 +119,7 @@ export default {
         "forceentrylist_label": "Force Entry List",
         "add_entry_button": "Add Entry",
         "clear_entries_button": "Clear all Entries"
+        "confirm_clear_entries": "Do you really want to remove all entries?",
     }
 }
 </i18n>

--- a/public/src/components/server_config/event.vue
+++ b/public/src/components/server_config/event.vue
@@ -175,6 +175,9 @@ export default {
             }
         },
         clearSessions() {
+            if (!window.confirm(this.$t("confirm_clear_sessions"))) {
+                return;
+            }
             while(this.sessions.length > 0) {
                 this.sessions.splice(this.sessions[this.sessions.length - 1], 1);
             }
@@ -210,6 +213,7 @@ export default {
         "add_sessions_q_r_button": "Add sessions (Q/R)",
         "add_sessions_p_q_r_button": "Add sessions (P/Q/R)",
         "clear_sessions_button": "Clear all Sessions"
+        "confirm_clear_sessions": "Do you really want to remove all sessions?",
     }
 }
 </i18n>

--- a/public/src/components/server_config/event.vue
+++ b/public/src/components/server_config/event.vue
@@ -212,8 +212,8 @@ export default {
         "add_session_button": "Add session",
         "add_sessions_q_r_button": "Add sessions (Q/R)",
         "add_sessions_p_q_r_button": "Add sessions (P/Q/R)",
-        "clear_sessions_button": "Clear all Sessions"
-        "confirm_clear_sessions": "Do you really want to remove all sessions?",
+        "clear_sessions_button": "Clear all Sessions",
+        "confirm_clear_sessions": "Do you really want to remove all sessions?"
     }
 }
 </i18n>

--- a/public/src/components/server_config/event.vue
+++ b/public/src/components/server_config/event.vue
@@ -28,6 +28,7 @@
           <button v-on:click="addSession">{{$t("add_session_button")}}</button>
           <button v-on:click="addDefaultSessions('Q/R')">{{$t("add_sessions_q_r_button")}}</button>
           <button v-on:click="addDefaultSessions('P/Q/R')">{{$t("add_sessions_p_q_r_button")}}</button>
+          <button v-on:click="clearSessions">{{$t("clear_sessions_button")}}</button>
         </div>
     </collapsible>
 </template>
@@ -173,6 +174,11 @@ export default {
                 }
             }
         },
+        clearSessions() {
+            while(this.sessions.length > 0) {
+                this.sessions.splice(this.sessions[this.sessions.length - 1], 1);
+            }
+        },
         toFloat(value) {
             if(typeof value === "string") {
                 return parseFloat(value.replace(",", "."));
@@ -202,7 +208,8 @@ export default {
         "isFixedConditionQualification_label": "Is Fixed Weather Conditions in Qualification",
         "add_session_button": "Add session",
         "add_sessions_q_r_button": "Add sessions (Q/R)",
-        "add_sessions_p_q_r_button": "Add sessions (P/Q/R)"
+        "add_sessions_p_q_r_button": "Add sessions (P/Q/R)",
+        "clear_sessions_button": "Clear all Sessions"
     }
 }
 </i18n>


### PR DESCRIPTION
Because the EntryList upload appends the new list to any existing Entries, the user has to individually remove all entries before uploading a new list.
To alleviate that in a 48car field :) I added a 'Clear all Entries' function and button to entrylist.vue. I hope it is useful.  (I have done the same for Sessions, but will await feedback)