### PR TITLE
feat: token timeout in configuration file

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.21.1-bullseye
+FROM golang:1.21-bullseye
 
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get install -y git build-essential nodejs zip
+    && apt-get install -y git build-essential nodejs="16.*" zip
 
 RUN go install golang.org/x/tools/gopls@latest \
     && go install github.com/go-delve/delve/cmd/dlv@latest \

--- a/build/docker/docker_config.yml
+++ b/build/docker/docker_config.yml
@@ -11,6 +11,7 @@ webserver:
   read_timeout: 5
   
 auth:
+  timeout: $ACCWEB_TIMEOUT
   admin_password: $ACCWEB_ADMIN_PASSWORD
   moderator_password: $ACCWEB_MOD_PASSWORD
   read_only_password: $ACCWEB_RO_PASSWORD

--- a/build/sample_config.yml
+++ b/build/sample_config.yml
@@ -21,6 +21,10 @@ webserver:
   read_timeout: 5
 
 auth:
+  # Set the session duration (Default value is 20 minutes).
+  # duration documentation can be found at https://pkg.go.dev/time#ParseDuration
+  timeout: 20m
+
   # Set the admin, moderator and read only user password.
   # accweb won't start without an admin password.
   admin_password: admin-password

--- a/dev_config.yml
+++ b/dev_config.yml
@@ -12,6 +12,7 @@ auth:
   admin_password: admin
   moderator_password: mod
   read_only_password: ro
+  timeout: 5h
 acc:
   server_path: "/app/fake-accserver/build/osx"
   server_exe: accServer.exe

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -165,7 +165,7 @@ func setupAuthRouters(r *gin.Engine, config *cfg.Config) *jwt.GinJWTMiddleware {
 		SigningAlgorithm: "RS256",
 		PrivKeyFile:      config.Auth.PrivateKeyPath,
 		PubKeyFile:       config.Auth.PublicKeyPath,
-		Timeout:          20 * time.Minute,
+		Timeout:          *config.Auth.Timeout,
 		MaxRefresh:       time.Hour,
 		IdentityKey:      identityKey,
 		PayloadFunc: func(data interface{}) jwt.MapClaims {

--- a/internal/pkg/cfg/cfg.go
+++ b/internal/pkg/cfg/cfg.go
@@ -1,7 +1,8 @@
 package cfg
 
 import (
-	"io/ioutil"
+	"os"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -40,11 +41,12 @@ type CORS struct {
 }
 
 type Auth struct {
-	PublicKeyPath     string `yaml:"public_key_path"`
-	PrivateKeyPath    string `yaml:"private_key_path"`
-	AdminPassword     string `yaml:"admin_password"`
-	ModeratorPassword string `yaml:"moderator_password"`
-	ReadOnlyPassword  string `yaml:"read_only_password"`
+	PublicKeyPath     string         `yaml:"public_key_path"`
+	PrivateKeyPath    string         `yaml:"private_key_path"`
+	AdminPassword     string         `yaml:"admin_password"`
+	ModeratorPassword string         `yaml:"moderator_password"`
+	ReadOnlyPassword  string         `yaml:"read_only_password"`
+	Timeout           *time.Duration `yaml:"timeout"`
 }
 
 type ACC struct {
@@ -54,7 +56,7 @@ type ACC struct {
 
 // Load loads the application config from config.yml.
 func Load(file string) *Config {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error loading configuration file")
 	}
@@ -74,6 +76,11 @@ func Load(file string) *Config {
 
 	if config.Auth.PublicKeyPath == "" {
 		config.Auth.PublicKeyPath = "secrets/token.public"
+	}
+
+	if config.Auth.Timeout == nil {
+		m5 := 5 * time.Minute
+		config.Auth.Timeout = &m5
 	}
 
 	skipWine = config.SkipWine


### PR DESCRIPTION
Add token timeout configuration

### config.yml

```yaml
# ...
auth:
  admin_password: admin
  moderator_password: mod
  read_only_password: ro
  timeout: 5h
``` 

Time Duration documentation: https://pkg.go.dev/time#ParseDuration

