### PR TITLE
Change default tyreSetCount in eventRules.json to 50

### DIFF
--- a/public/src/components/server_config/eventrules.vue
+++ b/public/src/components/server_config/eventrules.vue
@@ -37,7 +37,7 @@ export default {
         mandatoryPitstopCount: 0,
         maxTotalDrivingTime: -1,
         maxDriversCount: 1,
-        tyreSetCount: 0,
+        tyreSetCount: 50,
         isRefuellingAllowedInRace: true,
         isRefuellingTimeFixed: false,
         isMandatoryPitstopRefuellingRequired: false,


### PR DESCRIPTION
By default, accweb uses a value of 0 for tyreSetCount but in a driver swap event, the game will crash with a fatal error upon swapping drivers. This change is to set the tyreSetCount to 50 which prevents the fatal error.

Reference to opened issue:

https://github.com/assetto-corsa-web/accweb/issues/227