### PR TITLE
command-line option to override the default config.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ accweb is installed by extracting the zip on your server, modifing the YAML conf
 4. open a terminal
 5. change directory to the accweb installation location
 6. start accweb using `./accweb` on Linux and `accweb.exe` on Windows
+   - By using --config (-c) you can point to an alternative `config.yml` file, e.g. `./accweb --config server1.yml`
 8. leave the terminal open (or start in background using screens on Linux for example)
 9. visit the server IP/domain and port you've configured, for example: http://example.com:8080
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,9 +13,29 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const configFile = "config.yml"
+const configFileDefault = "config.yml"
 
 func main() {
+	var configFile string = configFileDefault
+
+	// Parse command line arguments
+	if len(os.Args) > 1 {
+		for i, arg := range os.Args[1:] {
+			if arg == "--config" || arg == "-c" {
+				if i+1 < len(os.Args)-1 {
+					configFile = os.Args[i+2]
+				} else {
+					logrus.Fatal("--config requires a value")
+				}
+				break
+			}
+			if arg == "--help" || arg == "-h" {
+				println("Usage: accweb [--config <config-file>]")
+				return
+			}
+		}
+	}
+
 	c := cfg.Load(configFile)
 
 	sM := server_manager.New(c)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"os"
 	"os/signal"
 	"syscall"
@@ -16,25 +17,11 @@ import (
 const configFileDefault = "config.yml"
 
 func main() {
-	var configFile string = configFileDefault
+	var configFile string
 
-	// Parse command line arguments
-	if len(os.Args) > 1 {
-		for i, arg := range os.Args[1:] {
-			if arg == "--config" || arg == "-c" {
-				if i+1 < len(os.Args)-1 {
-					configFile = os.Args[i+2]
-				} else {
-					logrus.Fatal("--config requires a value")
-				}
-				break
-			}
-			if arg == "--help" || arg == "-h" {
-				println("Usage: accweb [--config <config-file>]")
-				return
-			}
-		}
-	}
+	flag.StringVar(&configFile, "config", configFileDefault, "override configuration file")
+	flag.StringVar(&configFile, "c", configFileDefault, "override configuration file (shorthand)")
+	flag.Parse()
 
 	c := cfg.Load(configFile)
 


### PR DESCRIPTION
#292 

Added the command-line option --config/-c to override default config.yml, for example:

`./accweb --config server1.yml`